### PR TITLE
feat: Add unit test for elftool_dump

### DIFF
--- a/elftool_parse.c.gcov
+++ b/elftool_parse.c.gcov
@@ -1,0 +1,453 @@
+        -:    0:Source:src/elftool_parse.c
+        -:    0:Graph:/app/unit_test_elftool_parse/obj/src/elftool_parse.gcno
+        -:    0:Data:/app/unit_test_elftool_parse/obj/src/elftool_parse.gcda
+        -:    0:Runs:1
+        -:    1:#include "elftool.h"
+        -:    2:
+        1:    3:static int elftool_parse64_ehdr(elftool_t *bin) {
+        1:    4:  int r = 0;
+        -:    5:
+        1:    6:  if (((Elf64_Ehdr *)bin->mem)->e_phoff > bin->length) {
+    #####:    7:    _error(r, "e_phoff outside the scope");
+        -:    8:  }
+        1:    9:  if (r == 0) {
+        1:   10:    if (((Elf64_Ehdr *)bin->mem)->e_shoff > bin->length) {
+    #####:   11:      _error(r, "e_shoff outside the scope");
+        -:   12:    }
+        -:   13:  }
+        1:   14:  if (r == 0) {
+        1:   15:    if (((Elf64_Ehdr *)bin->mem)->e_phentsize *
+        1:   16:                ((Elf64_Ehdr *)bin->mem)->e_phnum +
+        1:   17:            ((Elf64_Ehdr *)bin->mem)->e_phoff >
+        1:   18:        bin->length) {
+    #####:   19:      _error(r, "phdr table run out of scope");
+        -:   20:    }
+        -:   21:  }
+        1:   22:  if (r == 0) {
+        1:   23:    if (((Elf64_Ehdr *)bin->mem)->e_shentsize *
+        1:   24:                ((Elf64_Ehdr *)bin->mem)->e_shnum +
+        1:   25:            ((Elf64_Ehdr *)bin->mem)->e_shoff >
+        1:   26:        bin->length) {
+    #####:   27:      _error(r, "shdr table run out of scope");
+        -:   28:    }
+        -:   29:  }
+        1:   30:  if (r == 0) {
+        1:   31:    bin->ehdr64 = (Elf64_Ehdr *)bin->mem;
+        -:   32:  }
+        1:   33:  return (r);
+        -:   34:}
+        -:   35:
+    #####:   36:static int elftool_parse32_ehdr(elftool_t *bin) {
+    #####:   37:  int r = 0;
+        -:   38:
+    #####:   39:  if (((Elf32_Ehdr *)bin->mem)->e_phoff > bin->length) {
+    #####:   40:    _error(r, "e_phoff outside the scope");
+        -:   41:  }
+    #####:   42:  if (r == 0) {
+    #####:   43:    if (((Elf32_Ehdr *)bin->mem)->e_shoff > bin->length) {
+    #####:   44:      _error(r, "e_shoff outside the scope");
+        -:   45:    }
+        -:   46:  }
+    #####:   47:  if (r == 0) {
+    #####:   48:    if (((Elf32_Ehdr *)bin->mem)->e_phentsize *
+    #####:   49:                ((Elf32_Ehdr *)bin->mem)->e_phnum +
+    #####:   50:            ((Elf32_Ehdr *)bin->mem)->e_phoff >
+    #####:   51:        bin->length) {
+    #####:   52:      _error(r, "phdr table run out of scope");
+        -:   53:    }
+        -:   54:  }
+    #####:   55:  if (r == 0) {
+    #####:   56:    if (((Elf32_Ehdr *)bin->mem)->e_shentsize *
+    #####:   57:                ((Elf32_Ehdr *)bin->mem)->e_shnum +
+    #####:   58:            ((Elf32_Ehdr *)bin->mem)->e_shoff >
+    #####:   59:        bin->length) {
+    #####:   60:      _error(r, "shdr table run out of scope");
+        -:   61:    }
+        -:   62:  }
+    #####:   63:  if (r == 0) {
+    #####:   64:    bin->ehdr32 = (Elf32_Ehdr *)bin->mem;
+        -:   65:  }
+    #####:   66:  return (r);
+        -:   67:}
+        -:   68:
+        1:   69:int elftool_parse_ehdr(elftool_t *bin) {
+        1:   70:  int offset = 0;
+        1:   71:  int r = 0;
+        -:   72:
+        1:   73:  if (!bin || !bin->mem) {
+    #####:   74:    _error(r, "Internal Error");
+        1:   75:  } else if (bin->length < 0x40) {
+    #####:   76:    _error(r, "Invalid length (<0x40)");
+        1:   77:  } else if (bin->mem[offset++] != 0x7f) {
+    #####:   78:    _error(r, "Invalid magic numer");
+        1:   79:  } else if (bin->mem[offset++] != 0x45) {
+    #####:   80:    _error(r, "Invalid magic numer");
+        1:   81:  } else if (bin->mem[offset++] != 0x4c) {
+    #####:   82:    _error(r, "Invalid magic numer");
+        1:   83:  } else if (bin->mem[offset++] != 0x46) {
+    #####:   84:    _error(r, "Invalid magic numer");
+        1:   85:  } else if (bin->mem[offset] != ELFCLASS32 && bin->mem[offset] != ELFCLASS64) {
+    #####:   86:    _error(r, "invalid EI_CLASS");
+        -:   87:  } else {
+        -:   88:    /* 32bits program or 64bits program */
+        1:   89:    bin->elfclass = bin->mem[offset++];
+       1*:   90:    if (bin->mem[offset] != ELFDATA2LSB && bin->mem[offset] != ELFDATA2MSB) {
+    #####:   91:      _error(r, "invalid EI_DATA");
+        -:   92:    }
+        -:   93:  }
+        1:   94:  if (r == 0) {
+        -:   95:    /* Endianness, affect fields starting from 0x10 */
+        1:   96:    bin->endian = bin->mem[offset++];
+        1:   97:    if (bin->mem[offset] > 0x12) {
+    #####:   98:      _error(r, "invalid EI_OSABI");
+        -:   99:    }
+        -:  100:  }
+        1:  101:  if (r == 0) {
+        -:  102:    /* It is class specific from 0x14 */
+        1:  103:    if (bin->elfclass == ELFCLASS32) {
+    #####:  104:      r = elftool_parse32_ehdr(bin);
+        -:  105:    } else {
+        1:  106:      r = elftool_parse64_ehdr(bin);
+        -:  107:    }
+        -:  108:  }
+        1:  109:  return (r);
+        -:  110:}
+    #####:  111:int elftool_parse_phdr_32(elftool_t *bin) {
+    #####:  112:  phdr32_t phdr = {0};
+    #####:  113:  t_list *new = NULL;
+    #####:  114:  uint32_t offset = bin->ehdr32->e_phoff;
+    #####:  115:  uint16_t idx = 0;
+    #####:  116:  int r = 0;
+        -:  117:
+    #####:  118:  while (r == 0 && idx < bin->ehdr32->e_phnum) {
+    #####:  119:    if (offset >= bin->length) {
+    #####:  120:      _error(r, "offset out of scope in phdr table");
+        -:  121:    }
+    #####:  122:    phdr.idx = idx;
+    #####:  123:    phdr.phdr = ((Elf32_Phdr *)&bin->mem[offset]);
+    #####:  124:    phdr.bin = bin;
+    #####:  125:    new = ft_lstnew(&phdr, sizeof(phdr));
+    #####:  126:    if (!new) {
+    #####:  127:      _error(r, "malloc error");
+        -:  128:    }
+    #####:  129:    ft_lstpush(&bin->phdr, new);
+    #####:  130:    offset += bin->ehdr32->e_phentsize;
+    #####:  131:    idx++;
+        -:  132:  }
+    #####:  133:  return (r);
+        -:  134:}
+        -:  135:
+    #####:  136:int elftool_parse_phdr_64(elftool_t *bin) {
+    #####:  137:  phdr64_t phdr = {0};
+    #####:  138:  t_list *new = NULL;
+    #####:  139:  uint64_t offset = bin->ehdr64->e_phoff;
+    #####:  140:  uint16_t idx = 0;
+    #####:  141:  int r = 0;
+        -:  142:
+    #####:  143:  while (r == 0 && idx < bin->ehdr64->e_phnum) {
+    #####:  144:    if (offset >= bin->length) {
+    #####:  145:      _error(r, "offset out of scope in phdr table");
+        -:  146:    }
+    #####:  147:    phdr.idx = idx;
+    #####:  148:    phdr.phdr = ((Elf64_Phdr *)&bin->mem[offset]);
+    #####:  149:    phdr.bin = bin;
+    #####:  150:    new = ft_lstnew(&phdr, sizeof(phdr));
+    #####:  151:    if (!new) {
+    #####:  152:      _error(r, "malloc error");
+        -:  153:    }
+    #####:  154:    ft_lstpush(&bin->phdr, new);
+    #####:  155:    offset += bin->ehdr64->e_phentsize;
+    #####:  156:    idx++;
+        -:  157:  }
+    #####:  158:  return (r);
+        -:  159:}
+        -:  160:
+    #####:  161:int elftool_parse_phdr(elftool_t *bin) {
+    #####:  162:  int r = 0;
+        -:  163:
+    #####:  164:  if (bin->elfclass == ELFCLASS32) {
+    #####:  165:    r = elftool_parse_phdr_32(bin);
+        -:  166:  } else {
+    #####:  167:    r = elftool_parse_phdr_64(bin);
+        -:  168:  }
+    #####:  169:  return (r);
+        -:  170:}
+        -:  171:
+    #####:  172:int elftool_parse_shdr_32(elftool_t *bin) {
+        -:  173:  t_list *head;
+    #####:  174:  shdr32_t shdr = {0};
+    #####:  175:  t_list *new = NULL;
+    #####:  176:  uint32_t offset = bin->ehdr32->e_shoff;
+    #####:  177:  int symtabstrndx = -1;
+    #####:  178:  uint16_t idx = 0;
+    #####:  179:  int r = 0;
+        -:  180:
+    #####:  181:  if (!bin || !bin->ehdr32) {
+    #####:  182:    r = -1;
+        -:  183:  } else {
+    #####:  184:    while (r == 0 && idx < bin->ehdr32->e_shnum) {
+    #####:  185:      if (offset >= bin->length) {
+    #####:  186:        _error(r, "offset out of scope in shdr table");
+        -:  187:      }
+    #####:  188:      if (r == 0) {
+    #####:  189:        shdr.idx = idx;
+    #####:  190:        shdr.shdr = ((Elf32_Shdr *)&bin->mem[offset]);
+    #####:  191:        shdr.mem = &bin->mem[shdr.shdr->sh_offset];
+    #####:  192:        shdr.bin = bin;
+        -:  193:      }
+    #####:  194:      if (r == 0) {
+    #####:  195:        new = ft_lstnew(&shdr, sizeof(shdr));
+    #####:  196:        if (!new) {
+    #####:  197:          _error(r, "malloc error");
+        -:  198:        }
+        -:  199:      }
+    #####:  200:      if (r == 0) {
+    #####:  201:        ft_lstpush(&bin->shdr, new);
+    #####:  202:        offset += bin->ehdr32->e_shentsize;
+    #####:  203:        idx++;
+    #####:  204:        if (shdr.shdr->sh_type == SHT_SYMTAB) {
+    #####:  205:          symtabstrndx = shdr.shdr->sh_link;
+        -:  206:        }
+        -:  207:      }
+        -:  208:    }
+    #####:  209:    if (symtabstrndx < 0) {
+    #####:  210:      _error(r, "symtab not found in sections");
+        -:  211:    }
+    #####:  212:    if (r == 0) {
+    #####:  213:      head = bin->shdr;
+    #####:  214:      while (head) {
+    #####:  215:        if (((shdr32_t *)head->content)->shdr->sh_type == SHT_STRTAB) {
+    #####:  216:          if (bin->ehdr32->e_shstrndx == ((shdr32_t *)head->content)->idx) {
+    #####:  217:            bin->shstrtab32 = ((shdr32_t *)head->content);
+        -:  218:          }
+    #####:  219:          if (symtabstrndx == ((shdr32_t *)head->content)->idx) {
+    #####:  220:            bin->strtab32 = ((shdr32_t *)head->content);
+        -:  221:          }
+        -:  222:        }
+    #####:  223:        head = head->next;
+        -:  224:      }
+        -:  225:    }
+        -:  226:  }
+    #####:  227:  return (r);
+        -:  228:}
+        -:  229:
+    #####:  230:int elftool_parse_shdr_64(elftool_t *bin) {
+        -:  231:  t_list *head;
+    #####:  232:  shdr64_t shdr = {0};
+    #####:  233:  t_list *new = NULL;
+    #####:  234:  uint64_t offset = bin->ehdr64->e_shoff;
+    #####:  235:  int symtabstrndx = -1;
+    #####:  236:  uint16_t idx = 0;
+    #####:  237:  int r = 0;
+        -:  238:
+    #####:  239:  if (!bin || !bin->ehdr64) {
+    #####:  240:    r = -1;
+        -:  241:  } else {
+    #####:  242:    while (r == 0 && idx < bin->ehdr64->e_shnum) {
+    #####:  243:      if (offset >= bin->length) {
+    #####:  244:        _error(r, "offset out of scope in shdr table");
+        -:  245:      }
+    #####:  246:      if (r == 0) {
+    #####:  247:        shdr.idx = idx;
+    #####:  248:        shdr.shdr = ((Elf64_Shdr *)&bin->mem[offset]);
+    #####:  249:        shdr.mem = &bin->mem[shdr.shdr->sh_offset];
+    #####:  250:        shdr.bin = bin;
+        -:  251:      }
+    #####:  252:      if (r == 0) {
+    #####:  253:        new = ft_lstnew(&shdr, sizeof(shdr));
+    #####:  254:        if (!new) {
+    #####:  255:          _error(r, "malloc error");
+        -:  256:        }
+        -:  257:      }
+    #####:  258:      if (r == 0) {
+    #####:  259:        ft_lstpush(&bin->shdr, new);
+    #####:  260:        if (shdr.shdr->sh_type == SHT_SYMTAB) {
+    #####:  261:          symtabstrndx = shdr.shdr->sh_link;
+        -:  262:        }
+    #####:  263:        offset += bin->ehdr64->e_shentsize;
+    #####:  264:        idx++;
+        -:  265:      }
+        -:  266:    }
+    #####:  267:    if (symtabstrndx < 0) {
+    #####:  268:      _error(r, "symtab not found in sections");
+        -:  269:    }
+    #####:  270:    if (r == 0) {
+    #####:  271:      head = bin->shdr;
+    #####:  272:      while (head) {
+    #####:  273:        if (((shdr64_t *)head->content)->shdr->sh_type == SHT_STRTAB) {
+    #####:  274:          if (bin->ehdr64->e_shstrndx == ((shdr64_t *)head->content)->idx) {
+    #####:  275:            bin->shstrtab64 = ((shdr64_t *)head->content);
+        -:  276:          }
+    #####:  277:          if (symtabstrndx == ((shdr64_t *)head->content)->idx) {
+    #####:  278:            bin->strtab64 = ((shdr64_t *)head->content);
+        -:  279:          }
+        -:  280:        }
+    #####:  281:        head = head->next;
+        -:  282:      }
+        -:  283:    }
+        -:  284:  }
+    #####:  285:  return (r);
+        -:  286:}
+        -:  287:
+    #####:  288:int elftool_parse_shdr(elftool_t *bin) {
+    #####:  289:  int r = 0;
+        -:  290:
+    #####:  291:  if (bin->elfclass == ELFCLASS32) {
+    #####:  292:    r = elftool_parse_shdr_32(bin);
+        -:  293:  } else {
+    #####:  294:    r = elftool_parse_shdr_64(bin);
+        -:  295:  }
+    #####:  296:  return (r);
+        -:  297:}
+        -:  298:
+    #####:  299:int elftool_parse_syms64(elftool_t *bin, void *symtab) {
+    #####:  300:  int r = 0;
+    #####:  301:  syms64_t syms = {0};
+    #####:  302:  t_list *new = NULL;
+    #####:  303:  uint16_t idx = 0;
+        -:  304:
+    #####:  305:  if (!bin || !symtab) {
+    #####:  306:    r = 0;
+        -:  307:  } else {
+    #####:  308:    for (uint64_t sym_offset = 0;
+    #####:  309:         r == 0 && sym_offset < ((Elf64_Shdr *)symtab)->sh_size;
+    #####:  310:         sym_offset += ((Elf64_Shdr *)symtab)->sh_entsize) {
+    #####:  311:      uint64_t offset = sym_offset + ((Elf64_Shdr *)symtab)->sh_offset;
+    #####:  312:      if (offset + sizeof(Elf64_Shdr) > bin->length) {
+    #####:  313:        _error(r, "offset out of scope in shdr table");
+        -:  314:      }
+    #####:  315:      if (r == 0) {
+    #####:  316:        syms.idx = idx++;
+    #####:  317:        syms.syms = (Elf64_Sym *)&bin->mem[offset];
+    #####:  318:        syms.bin = bin;
+    #####:  319:        if (!syms.bin->strtab64) {
+    #####:  320:          _error(r, "no strtab found");
+        -:  321:        }
+    #####:  322:        if (r == 0 && syms.syms->st_name + syms.bin->strtab64->shdr->sh_offset >
+    #####:  323:                          bin->length) {
+    #####:  324:          _error(r, "symbol name value out of scope");
+        -:  325:        }
+        -:  326:      }
+    #####:  327:      if (r == 0) {
+    #####:  328:        for (t_list *head = bin->shdr; head->next; head = head->next) {
+    #####:  329:          if (((shdr64_t *)head->content)->idx == syms.syms->st_shndx) {
+    #####:  330:            syms.shdr = ((shdr64_t *)head->content)->shdr;
+        -:  331:          }
+        -:  332:        }
+    #####:  333:        new = ft_lstnew(&syms, sizeof(syms64_t));
+    #####:  334:        if (!new) {
+    #####:  335:          _error(r, "malloc error");
+        -:  336:        } else {
+    #####:  337:          ft_lstpush(&bin->syms, new);
+        -:  338:        }
+        -:  339:      }
+        -:  340:    }
+        -:  341:  }
+    #####:  342:  return (r);
+        -:  343:}
+        -:  344:
+    #####:  345:int elftool_parse_syms32(elftool_t *bin, void *symtab) {
+    #####:  346:  int r = 0;
+    #####:  347:  syms32_t syms = {0};
+    #####:  348:  t_list *new = NULL;
+    #####:  349:  uint16_t idx = 0;
+        -:  350:
+    #####:  351:  if (!bin || !symtab) {
+    #####:  352:    r = 0;
+        -:  353:  } else {
+    #####:  354:    for (uint32_t sym_offset = 0;
+    #####:  355:         r == 0 && sym_offset < ((Elf32_Shdr *)symtab)->sh_size;
+    #####:  356:         sym_offset += ((Elf32_Shdr *)symtab)->sh_entsize) {
+    #####:  357:      uint32_t offset = sym_offset + ((Elf32_Shdr *)symtab)->sh_offset;
+    #####:  358:      if (offset + sizeof(Elf64_Shdr) > bin->length) {
+    #####:  359:        _error(r, "offset out of scope in shdr table");
+        -:  360:      }
+    #####:  361:      if (r == 0) {
+    #####:  362:        syms.idx = idx++;
+    #####:  363:        syms.syms = (Elf32_Sym *)&bin->mem[offset];
+    #####:  364:        syms.bin = bin;
+    #####:  365:        if (!syms.bin->strtab32) {
+    #####:  366:          _error(r, "no strtab found");
+        -:  367:        }
+    #####:  368:        if (r == 0 && syms.syms->st_name + syms.bin->strtab32->shdr->sh_offset >
+    #####:  369:                          bin->length) {
+    #####:  370:          _error(r, "symbol name value out of scope");
+        -:  371:        }
+        -:  372:      }
+    #####:  373:      if (r == 0) {
+    #####:  374:        for (t_list *head = bin->shdr; head->next; head = head->next) {
+    #####:  375:          if (((shdr32_t *)head->content)->idx == syms.syms->st_shndx) {
+    #####:  376:            syms.shdr = ((shdr32_t *)head->content)->shdr;
+        -:  377:          }
+        -:  378:        }
+    #####:  379:        new = ft_lstnew(&syms, sizeof(syms32_t));
+    #####:  380:        if (!new) {
+    #####:  381:          _error(r, "malloc error");
+        -:  382:        } else {
+    #####:  383:          ft_lstpush(&bin->syms, new);
+        -:  384:        }
+        -:  385:      }
+        -:  386:    }
+        -:  387:  }
+    #####:  388:  return (r);
+        -:  389:}
+        -:  390:
+    #####:  391:static int elftool_get_sym_sections(elftool_t *bin, void **symtab) {
+    #####:  392:  int r = 0;
+        -:  393:
+    #####:  394:  for (t_list *head = bin->shdr; head; head = head->next) {
+    #####:  395:    if (bin->elfclass == ELFCLASS32) {
+    #####:  396:      if (head->content &&
+    #####:  397:          ((shdr32_t *)head->content)->shdr->sh_type == SHT_SYMTAB) {
+    #####:  398:        *symtab = ((shdr32_t *)head->content)->shdr;
+        -:  399:      }
+        -:  400:    } else {
+    #####:  401:      if (head->content &&
+    #####:  402:          ((shdr64_t *)head->content)->shdr->sh_type == SHT_SYMTAB) {
+    #####:  403:        *symtab = ((shdr64_t *)head->content)->shdr;
+        -:  404:      }
+        -:  405:    }
+        -:  406:  }
+    #####:  407:  if (!symtab) {
+    #####:  408:    printf("missing symbol table in section entry\n");
+    #####:  409:    r = -1;
+        -:  410:  }
+    #####:  411:  return (r);
+        -:  412:}
+        -:  413:
+    #####:  414:int elftool_parse_syms(elftool_t *bin) {
+    #####:  415:  int r = 0;
+    #####:  416:  void *symtab = NULL;
+        -:  417:
+    #####:  418:  if (!bin) {
+    #####:  419:    r = -1;
+        -:  420:  } else {
+    #####:  421:    r = elftool_get_sym_sections(bin, &symtab);
+    #####:  422:    if (r == 0) {
+    #####:  423:      if (bin->elfclass == ELFCLASS32) {
+    #####:  424:        r = elftool_parse_syms32(bin, symtab);
+        -:  425:      } else {
+    #####:  426:        r = elftool_parse_syms64(bin, symtab);
+        -:  427:      }
+        -:  428:    }
+        -:  429:  }
+    #####:  430:  return (r);
+        -:  431:}
+        -:  432:
+    #####:  433:int elftool_parse(elftool_t *bin) {
+    #####:  434:  int r = 0;
+        -:  435:
+    #####:  436:  if (r == 0) {
+    #####:  437:    r = elftool_parse_ehdr(bin);
+        -:  438:  }
+    #####:  439:  if (r == 0) {
+    #####:  440:    r = elftool_parse_phdr(bin);
+        -:  441:  }
+    #####:  442:  if (r == 0) {
+    #####:  443:    r = elftool_parse_shdr(bin);
+        -:  444:  }
+    #####:  445:  if (r == 0) {
+    #####:  446:    r = elftool_parse_syms(bin);
+        -:  447:  }
+    #####:  448:  return (r);
+        -:  449:}

--- a/src/elftool_dump.c
+++ b/src/elftool_dump.c
@@ -94,21 +94,23 @@ static int sort_symbols64(elftool_t *bin) {
 
   // remove the first indice
   ft_lstdelone(&bin->syms, default_del);
-  while (ELF64_ST_TYPE(((syms64_t *)bin->syms->content)->syms->st_info) ==
+  while (bin->syms && (ELF64_ST_TYPE(((syms64_t *)bin->syms->content)->syms->st_info) ==
              STT_SECTION ||
          ELF64_ST_TYPE(((syms64_t *)bin->syms->content)->syms->st_info) ==
-             STT_FILE) {
+             STT_FILE)) {
     ft_lstdelone(&bin->syms, default_del);
   }
   head = bin->syms;
-  while (head->next) {
-    if (ELF64_ST_TYPE(((syms64_t *)head->next->content)->syms->st_info) ==
-            STT_SECTION ||
-        ELF64_ST_TYPE(((syms64_t *)head->next->content)->syms->st_info) ==
-            STT_FILE) {
-      ft_lstdelone(&head->next, default_del);
+  if (head) {
+    while (head->next) {
+      if (ELF64_ST_TYPE(((syms64_t *)head->next->content)->syms->st_info) ==
+              STT_SECTION ||
+          ELF64_ST_TYPE(((syms64_t *)head->next->content)->syms->st_info) ==
+              STT_FILE) {
+        ft_lstdelone(&head->next, default_del);
+      }
+      head = head->next;
     }
-    head = head->next;
   }
   while (bin->syms) {
     new = NULL;
@@ -117,10 +119,12 @@ static int sort_symbols64(elftool_t *bin) {
     index = 0;
     min = (char *)ff;
     while (head) {
+      fprintf(stderr, "sort_symbols64: head=%p\n", head);
       cur = (char *)&((syms64_t *)head->content)
                 ->bin->mem[((syms64_t *)head->content)
                                ->bin->strtab64->shdr->sh_offset +
                            ((syms64_t *)head->content)->syms->st_name];
+      fprintf(stderr, "sort_symbols64: cur=%s\n", cur);
       if (strcmp_nm(min, cur) > 0) {
         min = cur;
         indexSelected = index;
@@ -175,21 +179,23 @@ static int sort_symbols32(elftool_t *bin) {
 
   // remove the first indice
   ft_lstdelone(&bin->syms, default_del);
-  while (ELF32_ST_TYPE(((syms32_t *)bin->syms->content)->syms->st_info) ==
+  while (bin->syms && (ELF32_ST_TYPE(((syms32_t *)bin->syms->content)->syms->st_info) ==
              STT_SECTION ||
          ELF32_ST_TYPE(((syms32_t *)bin->syms->content)->syms->st_info) ==
-             STT_FILE) {
+             STT_FILE)) {
     ft_lstdelone(&bin->syms, default_del);
   }
   head = bin->syms;
-  while (head->next) {
-    if (ELF32_ST_TYPE(((syms32_t *)head->next->content)->syms->st_info) ==
-            STT_SECTION ||
-        ELF32_ST_TYPE(((syms32_t *)head->next->content)->syms->st_info) ==
-            STT_FILE) {
-      ft_lstdelone(&head->next, default_del);
+  if (head) {
+    while (head->next) {
+      if (ELF32_ST_TYPE(((syms32_t *)head->next->content)->syms->st_info) ==
+              STT_SECTION ||
+          ELF32_ST_TYPE(((syms32_t *)head->next->content)->syms->st_info) ==
+              STT_FILE) {
+        ft_lstdelone(&head->next, default_del);
+      }
+      head = head->next;
     }
-    head = head->next;
   }
   while (bin->syms) {
     new = NULL;

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,15 @@
+===== ELF HEADER
+Magic number and other info = 7f 45 4c 46
+Object file type = 0
+Architecture = 0
+Object file version = 0
+Entry point virtual address = 0
+Program header table file offset = 0
+Section header table file offset = 0
+Processor-specific flags = 0
+ELF header size in bytes = 0
+Program header table entry size = 0
+Program header table entry count = 0
+Section header table entry size = 0
+Section header table entry count = 0
+Section header string table index = 0

--- a/unit_test.mk
+++ b/unit_test.mk
@@ -27,6 +27,10 @@ SRC := \
 	$(UNIT_TEST_SRC)\
 	$(CMOCKA_PATH)/src/cmocka.c
 
+ifneq (,$(findstring elftool_dump,$(UNIT_NAME)))
+SRC += src/elftool_parse.c
+endif
+
 INCDIR := $(UNIT_INC_PATH) \
 	$(CMOCKA_PATH)/include
 
@@ -58,6 +62,7 @@ $(OBJ_DIR)/%.o: %.c
 $(JUNIT_REPORT) $(UNIT_GCDAFILE)&: $(BIN_NAME)
 	@mkdir -p $(dir $(JUNIT_REPORT))
 	$(BIN_NAME) > $(JUNIT_REPORT)
+
 
 $(BUILD_DIR)/report/html/coverage.html: $(UNIT_GCDAFILE)
 	@mkdir -p $(dir $@)

--- a/unit_test/test_elftool_dump.c
+++ b/unit_test/test_elftool_dump.c
@@ -1,0 +1,278 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include "cmocka.h"
+
+#include <elf.h>
+#include "elftool.h"
+#include "elftool_dump.h"
+#include "elftool_parse.h"
+
+static void test_elftool_dump_all(void **state) {
+  (void)state;
+  char buf[1024];
+  memset(buf, 0, 1024);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 1024,
+  };
+
+  // Create a 64-bit ELF file with all headers
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf64_Ehdr),
+      .e_shoff = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr),
+      .e_phentsize = sizeof(Elf64_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Phdr *phdr = (Elf64_Phdr *)(buf + sizeof(Elf64_Ehdr));
+  *phdr = (Elf64_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr));
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr) + sizeof(Elf64_Shdr) * 2,
+      .sh_size = sizeof(Elf64_Sym),
+      .sh_entsize = sizeof(Elf64_Sym),
+  };
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf64_Sym *sym = (Elf64_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf64_Sym){
+      .st_name = 0,
+  };
+
+  assert_int_equal(elftool_parse(&bin), 0);
+
+  elftool_opt_t opt = {
+    .ehdr = true,
+    .phdr = true,
+    .shdr = true,
+    .syms = true,
+    .nm = true,
+  };
+  elftool_dump(&opt, &bin);
+}
+
+static void test_elftool_dump_all_32(void **state) {
+  (void)state;
+  char buf[1024];
+  memset(buf, 0, 1024);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 1024,
+  };
+
+  // Create a 32-bit ELF file with all headers
+  Elf32_Ehdr *hdr = (Elf32_Ehdr *)buf;
+  *hdr = (Elf32_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS32, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf32_Ehdr),
+      .e_shoff = sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr),
+      .e_phentsize = sizeof(Elf32_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf32_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf32_Phdr *phdr = (Elf32_Phdr *)(buf + sizeof(Elf32_Ehdr));
+  *phdr = (Elf32_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf32_Shdr *shdr_tbl = (Elf32_Shdr *)(buf + sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr));
+  shdr_tbl[0] = (Elf32_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr) + sizeof(Elf32_Shdr) * 2,
+      .sh_size = sizeof(Elf32_Sym),
+      .sh_entsize = sizeof(Elf32_Sym),
+  };
+  shdr_tbl[1] = (Elf32_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf32_Sym *sym = (Elf32_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf32_Sym){
+      .st_name = 0,
+  };
+
+  assert_int_equal(elftool_parse(&bin), 0);
+
+  elftool_opt_t opt = {
+    .ehdr = true,
+    .phdr = true,
+    .shdr = true,
+    .syms = true,
+    .nm = true,
+  };
+  elftool_dump(&opt, &bin);
+}
+
+static void test_elftool_dump_weak_object(void **state) {
+  (void)state;
+  char buf[1024];
+  memset(buf, 0, 1024);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 1024,
+  };
+
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf64_Ehdr),
+      .e_shoff = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr),
+      .e_phentsize = sizeof(Elf64_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Phdr *phdr = (Elf64_Phdr *)(buf + sizeof(Elf64_Ehdr));
+  *phdr = (Elf64_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr));
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr) + sizeof(Elf64_Shdr) * 2,
+      .sh_size = sizeof(Elf64_Sym),
+      .sh_entsize = sizeof(Elf64_Sym),
+  };
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf64_Sym *sym = (Elf64_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf64_Sym){
+      .st_name = 0,
+      .st_info = ELF64_ST_INFO(STB_WEAK, STT_OBJECT),
+  };
+
+  assert_int_equal(elftool_parse(&bin), 0);
+
+  elftool_opt_t opt = {
+    .nm = true,
+  };
+  elftool_dump(&opt, &bin);
+}
+
+static void test_elftool_dump_shn_abs(void **state) {
+  (void)state;
+  char buf[1024];
+  memset(buf, 0, 1024);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 1024,
+  };
+
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf64_Ehdr),
+      .e_shoff = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr),
+      .e_phentsize = sizeof(Elf64_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Phdr *phdr = (Elf64_Phdr *)(buf + sizeof(Elf64_Ehdr));
+  *phdr = (Elf64_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr));
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr) + sizeof(Elf64_Shdr) * 2,
+      .sh_size = sizeof(Elf64_Sym),
+      .sh_entsize = sizeof(Elf64_Sym),
+  };
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf64_Sym *sym = (Elf64_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf64_Sym){
+      .st_name = 0,
+      .st_shndx = SHN_ABS,
+  };
+
+  assert_int_equal(elftool_parse(&bin), 0);
+
+  elftool_opt_t opt = {
+    .nm = true,
+  };
+  elftool_dump(&opt, &bin);
+}
+
+static void test_elftool_dump_stt_gnu_ifunc(void **state) {
+  (void)state;
+  char buf[1024];
+  memset(buf, 0, 1024);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 1024,
+  };
+
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf64_Ehdr),
+      .e_shoff = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr),
+      .e_phentsize = sizeof(Elf64_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Phdr *phdr = (Elf64_Phdr *)(buf + sizeof(Elf64_Ehdr));
+  *phdr = (Elf64_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr));
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr) + sizeof(Elf64_Shdr) * 2,
+      .sh_size = sizeof(Elf64_Sym),
+      .sh_entsize = sizeof(Elf64_Sym),
+  };
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf64_Sym *sym = (Elf64_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf64_Sym){
+      .st_name = 0,
+      .st_info = ELF64_ST_INFO(STB_GLOBAL, STT_GNU_IFUNC),
+  };
+
+  assert_int_equal(elftool_parse(&bin), 0);
+
+  elftool_opt_t opt = {
+    .nm = true,
+  };
+  elftool_dump(&opt, &bin);
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_elftool_dump_all),
+      cmocka_unit_test(test_elftool_dump_all_32),
+      cmocka_unit_test(test_elftool_dump_weak_object),
+      cmocka_unit_test(test_elftool_dump_shn_abs),
+      cmocka_unit_test(test_elftool_dump_stt_gnu_ifunc),
+  };
+  cmocka_set_message_output(CM_OUTPUT_XML);
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/unit_test/test_elftool_getopt.c
+++ b/unit_test/test_elftool_getopt.c
@@ -26,9 +26,107 @@ static void test_elftool_getopt(void **state) {
   assert_true(opt.nm == false);
 }
 
+static void test_elftool_getopt_help(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--help", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 1);
+}
+
+static void test_elftool_getopt_h(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "-h", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 1);
+}
+
+static void test_elftool_getopt_config(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--config", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_true(opt.config == true);
+}
+
+static void test_elftool_getopt_ehdr(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--elf-header", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_true(opt.ehdr == true);
+}
+
+static void test_elftool_getopt_section(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--section-header", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_true(opt.shdr == true);
+}
+
+static void test_elftool_getopt_hexdump(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--hexdump", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_true(opt.hexdump == true);
+}
+
+static void test_elftool_getopt_nm(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--nm", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_true(opt.nm == true);
+}
+
+static void test_elftool_getopt_test(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 2;
+  char *av[] = {"./nm", "--test", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  // assert_true(opt.test == true); // test is commented out in src
+}
+
+static void test_elftool_getopt_multiple_bins(void **state) {
+  (void)state;
+  elftool_opt_t opt = {0};
+  int ac = 4;
+  char *av[] = {"./nm", "bin1", "bin2", "bin3", NULL};
+  int r = elftool_getopt(ac, av, &opt);
+  assert_int_equal(r, 0);
+  assert_non_null(opt.bins);
+  elftool_printopt(&opt);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_elftool_getopt),
+      cmocka_unit_test(test_elftool_getopt_help),
+      cmocka_unit_test(test_elftool_getopt_h),
+      cmocka_unit_test(test_elftool_getopt_config),
+      cmocka_unit_test(test_elftool_getopt_ehdr),
+      cmocka_unit_test(test_elftool_getopt_section),
+      cmocka_unit_test(test_elftool_getopt_hexdump),
+      cmocka_unit_test(test_elftool_getopt_nm),
+      cmocka_unit_test(test_elftool_getopt_test),
+      cmocka_unit_test(test_elftool_getopt_multiple_bins),
   };
   cmocka_set_message_output(CM_OUTPUT_XML);
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit_test/test_elftool_parse.c
+++ b/unit_test/test_elftool_parse.c
@@ -9,6 +9,7 @@
 
 #include <elf.h>
 #include "elftool_parse.h"
+#include <string.h>
 
 static void test_elftool_parse64_ehdr(void **state) {
   (void)state;
@@ -32,9 +33,174 @@ static void test_elftool_parse64_ehdr(void **state) {
   assert_ptr_equal(bin.ehdr64, &hdr);
 }
 
+static void test_elftool_parse64_phdr(void **state) {
+  (void)state;
+  char buf[200];
+  memset(buf, 0, 200);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 200,
+  };
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf64_Ehdr),
+      .e_shoff = 0,
+      .e_phentsize = sizeof(Elf64_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = 0,
+      .e_shnum = 0,
+  };
+  Elf64_Phdr *phdr = (Elf64_Phdr *)(buf + sizeof(Elf64_Ehdr));
+  *phdr = (Elf64_Phdr){
+      .p_type = PT_LOAD,
+  };
+
+  int r = elftool_parse_ehdr(&bin);
+  assert_int_equal(r, 0);
+  r = elftool_parse_phdr(&bin);
+  assert_int_equal(r, 0);
+  assert_non_null(bin.phdr);
+}
+
+static void test_elftool_parse64_shdr(void **state) {
+  (void)state;
+  char buf[300];
+  memset(buf, 0, 300);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 300,
+  };
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = 0,
+      .e_shoff = sizeof(Elf64_Ehdr),
+      .e_phentsize = 0,
+      .e_phnum = 0,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr));
+  // SYMTAB
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+  };
+  // STRTAB for shdr names
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+
+  int r = elftool_parse_ehdr(&bin);
+  assert_int_equal(r, 0);
+  r = elftool_parse_shdr(&bin);
+  assert_int_equal(r, 0);
+  assert_non_null(bin.shdr);
+}
+
+static void test_elftool_parse64_syms(void **state) {
+  (void)state;
+  char buf[500];
+  memset(buf, 0, 500);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 500,
+  };
+  Elf64_Ehdr *hdr = (Elf64_Ehdr *)buf;
+  *hdr = (Elf64_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS64, ELFDATA2LSB, 0x11},
+      .e_phoff = 0,
+      .e_shoff = sizeof(Elf64_Ehdr),
+      .e_phentsize = 0,
+      .e_phnum = 0,
+      .e_shentsize = sizeof(Elf64_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf64_Shdr *shdr_tbl = (Elf64_Shdr *)(buf + sizeof(Elf64_Ehdr));
+  // SYMTAB
+  shdr_tbl[0] = (Elf64_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf64_Ehdr) + sizeof(Elf64_Shdr) * 2,
+      .sh_size = sizeof(Elf64_Sym),
+      .sh_entsize = sizeof(Elf64_Sym),
+  };
+  // STRTAB for shdr names
+  shdr_tbl[1] = (Elf64_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf64_Sym *sym = (Elf64_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf64_Sym){
+      .st_name = 0,
+  };
+
+  int r = elftool_parse_ehdr(&bin);
+  assert_int_equal(r, 0);
+  r = elftool_parse_shdr(&bin);
+  assert_int_equal(r, 0);
+  r = elftool_parse_syms(&bin);
+  assert_int_equal(r, 0);
+  assert_non_null(bin.syms);
+}
+
+static void test_elftool_parse32_all(void **state) {
+  (void)state;
+  char buf[500];
+  memset(buf, 0, 500);
+  elftool_t bin = {
+      .mem = (void *)buf,
+      .length = 500,
+  };
+  Elf32_Ehdr *hdr = (Elf32_Ehdr *)buf;
+  *hdr = (Elf32_Ehdr){
+      .e_ident = {0x7f, 0x45, 0x4c, 0x46, ELFCLASS32, ELFDATA2LSB, 0x11},
+      .e_phoff = sizeof(Elf32_Ehdr),
+      .e_shoff = sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr),
+      .e_phentsize = sizeof(Elf32_Phdr),
+      .e_phnum = 1,
+      .e_shentsize = sizeof(Elf32_Shdr),
+      .e_shnum = 2,
+      .e_shstrndx = 1,
+  };
+  Elf32_Phdr *phdr = (Elf32_Phdr *)(buf + sizeof(Elf32_Ehdr));
+  *phdr = (Elf32_Phdr){
+      .p_type = PT_LOAD,
+  };
+  Elf32_Shdr *shdr_tbl = (Elf32_Shdr *)(buf + sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr));
+  // SYMTAB
+  shdr_tbl[0] = (Elf32_Shdr){
+      .sh_type = SHT_SYMTAB,
+      .sh_link = 1,
+      .sh_offset = sizeof(Elf32_Ehdr) + sizeof(Elf32_Phdr) + sizeof(Elf32_Shdr) * 2,
+      .sh_size = sizeof(Elf32_Sym),
+      .sh_entsize = sizeof(Elf32_Sym),
+  };
+  // STRTAB for shdr names
+  shdr_tbl[1] = (Elf32_Shdr){
+      .sh_type = SHT_STRTAB,
+  };
+  Elf32_Sym *sym = (Elf32_Sym *)(buf + shdr_tbl[0].sh_offset);
+  *sym = (Elf32_Sym){
+      .st_name = 0,
+  };
+
+  int r = elftool_parse(&bin);
+  assert_int_equal(r, 0);
+  assert_non_null(bin.phdr);
+  assert_non_null(bin.shdr);
+  assert_non_null(bin.syms);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_elftool_parse64_ehdr),
+      cmocka_unit_test(test_elftool_parse64_phdr),
+      cmocka_unit_test(test_elftool_parse64_shdr),
+      cmocka_unit_test(test_elftool_parse64_syms),
+      cmocka_unit_test(test_elftool_parse32_all),
   };
   cmocka_set_message_output(CM_OUTPUT_XML);
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This commit adds a new unit test for the `elftool_dump` module. The test covers both 32-bit and 64-bit ELF files, and it exercises the various dump functions, including the `nm` output.

This commit also fixes a segmentation fault in the `sort_symbols64` and `sort_symbols32` functions that occurred when the symbol list was empty.

Also improve existing test coverage.